### PR TITLE
Added array-like min and max actions

### DIFF
--- a/DDPG.py
+++ b/DDPG.py
@@ -13,20 +13,21 @@ device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
 
 class Actor(nn.Module):
-	def __init__(self, state_dim, action_dim, max_action):
+	def __init__(self, state_dim, action_dim, min_action, max_action):
 		super(Actor, self).__init__()
 
 		self.l1 = nn.Linear(state_dim, 400)
 		self.l2 = nn.Linear(400, 300)
 		self.l3 = nn.Linear(300, action_dim)
 		
-		self.max_action = max_action
+		self.min_action = torch.FloatTensor(min_action)
+		self.max_action = torch.FloatTensor(max_action)
 
 	
 	def forward(self, state):
 		a = F.relu(self.l1(state))
 		a = F.relu(self.l2(a))
-		return self.max_action * torch.tanh(self.l3(a))
+		return (self.max_action - self.min_action) * ((torch.tanh(self.l3(a)) + 1) / 2) + self.min_action
 
 
 class Critic(nn.Module):
@@ -45,8 +46,8 @@ class Critic(nn.Module):
 
 
 class DDPG(object):
-	def __init__(self, state_dim, action_dim, max_action, discount=0.99, tau=0.001):
-		self.actor = Actor(state_dim, action_dim, max_action).to(device)
+	def __init__(self, state_dim, action_dim, min_action, max_action, discount=0.99, tau=0.001):
+		self.actor = Actor(state_dim, action_dim, min_action, max_action).to(device)
 		self.actor_target = copy.deepcopy(self.actor)
 		self.actor_optimizer = torch.optim.Adam(self.actor.parameters(), lr=1e-4)
 

--- a/OurDDPG.py
+++ b/OurDDPG.py
@@ -12,20 +12,21 @@ device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
 
 class Actor(nn.Module):
-	def __init__(self, state_dim, action_dim, max_action):
+	def __init__(self, state_dim, action_dim, min_action, max_action):
 		super(Actor, self).__init__()
 
 		self.l1 = nn.Linear(state_dim, 400)
 		self.l2 = nn.Linear(400, 300)
 		self.l3 = nn.Linear(300, action_dim)
 		
-		self.max_action = max_action
+		self.min_action = torch.FloatTensor(min_action)
+		self.max_action = torch.FloatTensor(max_action)
 
 	
 	def forward(self, state):
 		a = F.relu(self.l1(state))
 		a = F.relu(self.l2(a))
-		return self.max_action * torch.tanh(self.l3(a))
+		return (self.max_action - self.min_action) * ((torch.tanh(self.l3(a)) + 1) / 2) + self.min_action
 
 
 class Critic(nn.Module):
@@ -44,8 +45,8 @@ class Critic(nn.Module):
 
 
 class DDPG(object):
-	def __init__(self, state_dim, action_dim, max_action, discount=0.99, tau=0.005):
-		self.actor = Actor(state_dim, action_dim, max_action).to(device)
+	def __init__(self, state_dim, action_dim, min_action, max_action, discount=0.99, tau=0.005):
+		self.actor = Actor(state_dim, action_dim, min_action, max_action).to(device)
 		self.actor_target = copy.deepcopy(self.actor)
 		self.actor_optimizer = torch.optim.Adam(self.actor.parameters())
 

--- a/TD3.py
+++ b/TD3.py
@@ -12,20 +12,21 @@ device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
 
 class Actor(nn.Module):
-	def __init__(self, state_dim, action_dim, max_action):
+	def __init__(self, state_dim, action_dim, min_action, max_action):
 		super(Actor, self).__init__()
 
 		self.l1 = nn.Linear(state_dim, 256)
 		self.l2 = nn.Linear(256, 256)
 		self.l3 = nn.Linear(256, action_dim)
 		
-		self.max_action = max_action
+		self.min_action = torch.FloatTensor(min_action)
+		self.max_action = torch.FloatTensor(max_action)
 		
 
 	def forward(self, state):
 		a = F.relu(self.l1(state))
 		a = F.relu(self.l2(a))
-		return self.max_action * torch.tanh(self.l3(a))
+		return (self.max_action - self.min_action) * ((torch.tanh(self.l3(a)) + 1) / 2) + self.min_action
 
 
 class Critic(nn.Module):
@@ -70,6 +71,7 @@ class TD3(object):
 		self,
 		state_dim,
 		action_dim,
+		min_action,
 		max_action,
 		discount=0.99,
 		tau=0.005,
@@ -78,7 +80,7 @@ class TD3(object):
 		policy_freq=2
 	):
 
-		self.actor = Actor(state_dim, action_dim, max_action).to(device)
+		self.actor = Actor(state_dim, action_dim, min_action, max_action).to(device)
 		self.actor_target = copy.deepcopy(self.actor)
 		self.actor_optimizer = torch.optim.Adam(self.actor.parameters(), lr=3e-4)
 
@@ -86,11 +88,12 @@ class TD3(object):
 		self.critic_target = copy.deepcopy(self.critic)
 		self.critic_optimizer = torch.optim.Adam(self.critic.parameters(), lr=3e-4)
 
-		self.max_action = max_action
+		self.min_action = torch.FloatTensor(min_action)
+		self.max_action = torch.FloatTensor(max_action)
 		self.discount = discount
 		self.tau = tau
-		self.policy_noise = policy_noise
-		self.noise_clip = noise_clip
+		self.policy_noise = torch.FloatTensor(policy_noise)
+		self.noise_clip = torch.FloatTensor(noise_clip)
 		self.policy_freq = policy_freq
 
 		self.total_it = 0
@@ -109,13 +112,13 @@ class TD3(object):
 
 		with torch.no_grad():
 			# Select action according to policy and add clipped noise
-			noise = (
-				torch.randn_like(action) * self.policy_noise
-			).clamp(-self.noise_clip, self.noise_clip)
+			noise = torch.max(
+				torch.min(torch.randn_like(action) * self.policy_noise, self.noise_clip
+			), -self.noise_clip)
 			
-			next_action = (
-				self.actor_target(next_state) + noise
-			).clamp(-self.max_action, self.max_action)
+			next_action = torch.max(
+				torch.min(self.actor_target(next_state) + noise, self.max_action
+			), self.min_action)
 
 			# Compute the target Q value
 			target_Q1, target_Q2 = self.critic_target(next_state, next_action)


### PR DESCRIPTION
1) Added a minimum action variable, included it as the lower bound for action clipping, and modified necessary range calculations.
2) Changed minimum and maximum action variables to be array-like instead of single floating point variables. `torch.clamp` doesn't support tensor min and max inputs therefore `torch.min` and `torch.max` have to be used instead.

The changes have been tested on Pendulum-v0 and some custom environments with array-like action spaces to ensure clipping and minimum action are handled properly.